### PR TITLE
Get rid of warnings about get_lr() and zero division.

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -15,7 +15,7 @@ dev = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
 test_loader = get_test_loaders(opt)
 
-path = 'weights/sunet-32.pt'   # the path of the model
+path = 'weights/snunet-32.pt'   # the path of the model
 model = torch.load(path)
 
 c_matrix = {'tn': 0, 'fp': 0, 'fn': 0, 'tp': 0}

--- a/train.py
+++ b/train.py
@@ -107,13 +107,14 @@ for epoch in range(opt.epochs):
         cd_train_report = prfs(labels.data.cpu().numpy().flatten(),
                                cd_preds.data.cpu().numpy().flatten(),
                                average='binary',
+                               zero_division=0,
                                pos_label=1)
 
         train_metrics = set_metrics(train_metrics,
                                     cd_loss,
                                     cd_corrects,
                                     cd_train_report,
-                                    scheduler.get_lr())
+                                    scheduler.get_last_lr())
 
         # log the batch mean metrics
         mean_train_metrics = get_mean_metrics(train_metrics)
@@ -154,13 +155,14 @@ for epoch in range(opt.epochs):
             cd_val_report = prfs(labels.data.cpu().numpy().flatten(),
                                  cd_preds.data.cpu().numpy().flatten(),
                                  average='binary',
+                                 zero_division=0,
                                  pos_label=1)
 
             val_metrics = set_metrics(val_metrics,
                                       cd_loss,
                                       cd_corrects,
                                       cd_val_report,
-                                      scheduler.get_lr())
+                                      scheduler.get_last_lr())
 
             # log the batch mean metrics
             mean_val_metrics = get_mean_metrics(val_metrics)


### PR DESCRIPTION
Changed get_lr() to get_last_lr() and added zero_division=0 to get rid of warning messages.